### PR TITLE
feat: add rollup ES and CJS bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,23 +23,31 @@
     "babel-preset-es2015": "~6",
     "babel-preset-stage-1": "~6",
     "babel-traverse": "6.3.19",
-    "gulp-jasmine": "^2.2.1",
-    "jasmine-reporters": "^2.1.1",
-    "jasmine-spec-reporter": "^2.4.0",
-    "json-loader": "^0.5.4",
     "chai": "^3.5.0",
     "chai-jquery": "^2.0.0",
+    "gulp-jasmine": "^2.2.1",
+    "gulp-sourcemaps": "2.2.0",
+    "jasmine-reporters": "^2.1.1",
+    "jasmine-spec-reporter": "^2.4.0",
     "jquery": "^2.2.1",
-    "source-map-loader": "^0.1.5"
+    "json-loader": "^0.5.4",
+    "rollup-plugin-buble": "0.14.0",
+    "rollup-stream": "1.14.0",
+    "source-map-loader": "^0.1.5",
+    "vinyl-buffer": "1.0.0",
+    "vinyl-source-stream": "1.1.0"
   },
   "author": "Telerik",
   "license": "Apache-2.0",
   "devDependencies": {
+    "babel-eslint": "^5.0.0",
     "cz-conventional-changelog": "^1.1.5",
+    "eslint": "1.10.3",
+    "eslint-plugin-react": "^3.0.0",
     "ghooks": "^1.0.3",
     "json-loader": "^0.5.4",
-    "validate-commit-msg": "^1.1.1",
-    "semantic-release": "^4.3.5"
+    "semantic-release": "^4.3.5",
+    "validate-commit-msg": "^1.1.1"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Added a parallel set of tasks for building ES and CJS bundles. Packages can opt-in to output the new bundles by using `gulp build-rollup-package`. Prerequisite for telerik/kendo-angular2#80

* [Rollup](https://github.com/rollup/rollup) was chosen as it has support for ES modules. Webpack2 is still not official to this date.
* [Buble](https://buble.surge.sh) was chosen as it produces much smaller code and has simpler feature set and configuration. The packages we're aiming to support here shouldn't rely on fancy Babel plugins and polyfills anyway.

Note that these bundles are only suitable for libraries as they package only code and type definitions.

/cc @gyoshev @rkonstantinov 