### PR TITLE
feat: support multiple entries in CJS bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "jasmine-spec-reporter": "^2.4.0",
     "jquery": "^2.2.1",
     "json-loader": "^0.5.4",
+    "merge2": "1.0.3",
     "rimraf": "^2.5.4",
     "rollup-plugin-buble": "0.14.0",
     "rollup-stream": "1.14.0",


### PR DESCRIPTION
Adds support for producing multiple entry points in the CJS bundle (`dist/npm`).

Sample usage in packages:
```js
const gulp = require('gulp');

require('@telerik/kendo-package-tasks')(gulp, 'kendo-drawing', {
    entries: ['drawing.js', 'geometry.js', 'main.js', 'pdf.js']
});
```