### PR TITLE
chore: upgrade kendo-common-tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "dependencies": {
     "@telerik/eslint-config": "^1.1.0",
-    "@telerik/kendo-common-tasks": "^2.0.0",
+    "@telerik/kendo-common-tasks": "^3.0.0",
     "babel-core": "^6.0.0",
     "babel-loader": "^6.2.0",
     "babel-plugin-add-module-exports": "^0.1.2",


### PR DESCRIPTION
In order to start kendo-charts e2e tests we need to apply new karma options introduced [here](https://github.com/telerik/kendo-common-tasks/releases/tag/v3.0.13)