### PR TITLE
fix: exclude peer dependencies from UMD bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,8 +7,12 @@ const nodeModulesPath = path.join(__dirname, 'node_modules');
 const resolve = commonTasks.resolveConfig(sourceExtensions, nodeModulesPath);
 
 const packageInfo = require(path.join(process.cwd(), 'package.json'));
-const packageDependencies = Object.keys(packageInfo["dependencies"] || {})
+const packageDependencies =
+    Object.keys(packageInfo["dependencies"] || {}).concat(
+        Object.keys(packageInfo["peerDependencies"] || {})
+    )
     .map(dep => new RegExp(`^${dep}`));
+
 
 const babelLoader = {
     test: /\.js?$/,


### PR DESCRIPTION
Removes kendo-drawing from the kendo-charts UMD bundle. Other packages based on package-tasks do not seem to list any peer dependencies. 

/cc @gyoshev 